### PR TITLE
Incompatible return type declaration

### DIFF
--- a/Block/Container.php
+++ b/Block/Container.php
@@ -43,7 +43,7 @@ class Container extends \Magento\Framework\View\Element\Template implements Iden
         ]);
     }
 
-    public function getCacheLifetime(): int
+    public function getCacheLifetime()
     {
         return parent::getCacheLifetime() ?: 3600;
     }


### PR DESCRIPTION
parent::getCacheLifetime() returns int|bool|null (signature)

https://github.com/magento/magento2/blob/177254d988680b4a2457603c70a8ad6005356500/lib/internal/Magento/Framework/View/Element/AbstractBlock.php#L1085