### PR TITLE
Prefix block name with block name in layout

### DIFF
--- a/Block/Container.php
+++ b/Block/Container.php
@@ -96,7 +96,7 @@ class Container extends \Magento\Framework\View\Element\Template implements Iden
     private function createBlockFromData(array $blockData): Element
     {
         $block = $this->getLayout()
-            ->createBlock(Element::class, $blockData['_uid'])
+            ->createBlock(Element::class, $this->getNameInLayout() . '_' . $blockData['_uid'])
             ->setData($blockData);
 
         $templatePath = $this->viewFileSystem->getTemplateFileName(

--- a/Block/Container.php
+++ b/Block/Container.php
@@ -96,8 +96,11 @@ class Container extends \Magento\Framework\View\Element\Template implements Iden
     private function createBlockFromData(array $blockData): Element
     {
         $block = $this->getLayout()
-            ->createBlock(Element::class, $this->getNameInLayout() . '_' . $blockData['_uid'])
-            ->setData($blockData);
+        ->createBlock(
+            Element::class,
+            $this->getNameInLayout() ? ($this->getNameInLayout() . '_' . $blockData['_uid']) : $blockData['_uid']
+        )
+        ->setData($blockData);
 
         $templatePath = $this->viewFileSystem->getTemplateFileName(
             "MediaLounge_Storyblok::story/{$blockData['component']}.phtml"


### PR DESCRIPTION
This prevents an error Magento throws when you output the same story on one page and have block_html cache disabled. For example when you are outputting some content entry in the header and in the footer.

The exception I received was:

```
1 exception(s):
Exception #0 (Magento\Framework\Exception\LocalizedException): An element with a "5d2193ec-e230-4fcf-89c7-0c569ca90e86" ID already exists.
```

Example layout:

```
<referenceContainer name="content">
    <block class="MediaLounge\Storyblok\Block\Container" name="button1">
        <arguments>
            <argument name="slug" xsi:type="string">theme/button</argument>
        </arguments>
    </block>
    <block class="MediaLounge\Storyblok\Block\Container" name="button2">
        <arguments>
            <argument name="slug" xsi:type="string">theme/button</argument>
        </arguments>
    </block>
</referenceContainer>
```

This will create 2 blocks prefixed with `button1_` and `button2_`.
