### PR TITLE
Add dynamic method for getting specific child blocks

### DIFF
--- a/Block/Container/Element.php
+++ b/Block/Container/Element.php
@@ -41,4 +41,36 @@ class Element extends \Magento\Framework\View\Element\Template
 
         return $imageService . $param . $resource;
     }
+
+    public function __call($method, $args)
+    {
+        // check for minimum length of 7 ('get' and 'html')
+        if (!strlen($method) > 7) {
+            return parent::__call($method, $args);
+        }
+        $start = substr($method, 0, 3);
+        $end = substr($method, -4);
+        if ($start === 'get' && $end === 'Html') {
+            $key = strtolower(substr($method, 3, -4));
+            return $this->getStoryBlockChilds($key);
+        }
+        return parent::__call($method, $args);
+    }
+
+    protected function getStoryBlockChilds(string $key): ?string
+    {
+        $data = $this->getData($key);
+        if (!$data) {
+            return null;
+        }
+
+        $name = $this->getNameInLayout();
+        $namePrefix = substr($name, 0, strrpos($name, '_') + 1);
+
+        $html = '';
+        foreach ($data as $row) {
+            $html .= $this->getChildHtml($namePrefix . $row['_uid']);
+        }
+        return $html;
+    }
 }


### PR DESCRIPTION
This PR depends on https://github.com/Media-Lounge/magento2-storyblok-integration/pull/25 being merged first.

This PR adds the ability to get specific child blocks in the template. So for example, if I have a `menu` component with a "Blocks" type field called `menuitems` I can get the childHtml for those items with:

```
$block->getMenuitemsHtml()
```

This is useful if you have multiple fields with blocks and you want to control which one to get in your template.