### PR TITLE
Add option to get stories by folder per store view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 node_modules
 composer.lock
 .phpunit.result.cache
+.idea/

--- a/Controller/Router.php
+++ b/Controller/Router.php
@@ -71,6 +71,13 @@ class Router implements RouterInterface
     public function match(RequestInterface $request): ?ActionInterface
     {
         $identifier = trim($request->getPathInfo(), '/');
+        $topLevelFolder = $this->scopeConfig->getValue(
+            'storyblok/general/top_folder',
+            ScopeInterface::SCOPE_STORE,
+            $this->storeManager->getStore()->getId()
+        );
+
+        $identifier = $topLevelFolder . "/{$identifier}";
 
         try {
             $data = $this->cache->load($identifier);

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -29,6 +29,13 @@
                         <field id="storyblok/general/enabled">1</field>
                     </depends>
                 </field>
+                <field id="top_folder" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Top Level Folder</label>
+                    <comment><![CDATA[Set the top level <a href="https://www.storyblok.com/docs/terminology/folder" target="_blank">folder</a> to seperate stories for each Magento store and/or for store <a href="https://www.storyblok.com/docs/guide/in-depth/internationalization#folder-level-translation" target="_blank">internationalization</a>. e.g. fr-fr]]></comment>
+                    <depends>
+                        <field id="storyblok/general/enabled">1</field>
+                    </depends>
+                </field>
             </group>
         </section>
         <section id="sitemap">


### PR DESCRIPTION
Adds a new Sys Config option for the top level folder in-which Storyblok stories are contained.

![Screenshot 2021-11-25 at 16 46 01](https://user-images.githubusercontent.com/2452991/143470690-5bee8e96-a35b-444c-9e84-b03baf4d6b13.png)


May be used for:
- multi-language Magento installs for folder-level translations.
https://www.storyblok.com/docs/guide/in-depth/internationalization#folder-level-translation
- multi website / store view Magento installs to manage all stories from
one space.

![Screenshot 2021-11-25 at 16 50 00](https://user-images.githubusercontent.com/2452991/143471226-6b5f437d-3f64-4da5-8b91-f584bcdc1348.png)
