### PR TITLE
Assign element uid to relationship between parent and child

### DIFF
--- a/Block/Container.php
+++ b/Block/Container.php
@@ -133,7 +133,7 @@ class Container extends \Magento\Framework\View\Element\Template implements Iden
 
                     $childBlock = $this->createBlockFromData($childData);
 
-                    $parentBlock->append($childBlock);
+                    $parentBlock->append($childBlock, $childBlock->getData('_uid'));
                 }
             }
         }


### PR DESCRIPTION
Today it's impossible to retrieve and specific child block from a parent using its `_uid` because there's not an alias linking the child to the parent, so code like below will return anything.

```php
<?php 
$buttonElement = $parent->getButton();

if ($buttonElement):
?>
    <div>
        <?= $parent->getChildHtml($buttonElement[0]['_uid']) ?>
    </div>
<?php endif; ?>
```

The reason for this is due to the method `getChildHtml` that calls `\Magento\Framework\Data\Structure::getChildId` method to retrieve the child block. Below a snippet of this method.

```php
public function getChildId($parentId, $alias)
{
    if (isset($this->_elements[$parentId][self::CHILDREN])) {
        return array_search($alias, $this->_elements[$parentId][self::CHILDREN]);
    }
    return false;
}
```
This method uses `$alias' to retrieve the child block.

To make it possible the method `\Magento\Framework\View\Element\AbstractBlock::append` receives a second parameter with this alias and this PR uses this to fix this issue.